### PR TITLE
ci: auto bump version if is same version in npm

### DIFF
--- a/.makefiles/bump_version.sh
+++ b/.makefiles/bump_version.sh
@@ -26,8 +26,7 @@ if [ -f $VERSION ]; then
     V_PATCH=${BASE_LIST[2]}
     echo -e "${NOTICE_FLAG} Current version: ${WHITE}$BASE_STRING"
     echo -e "${NOTICE_FLAG} Latest commit hash: ${WHITE}$LATEST_HASH"
-    V_MINOR=$((V_MINOR + 1))
-    V_PATCH=0
+    V_PATCH=$((V_PATCH + 1))
     SUGGESTED_VERSION="$V_MAJOR.$V_MINOR.$V_PATCH"
     if [ "$SKIP_INPUT" = "" ]; then
         echo -ne "${QUESTION_FLAG} ${CYAN}Enter a version number [${WHITE}$SUGGESTED_VERSION${CYAN}]: "

--- a/.makefiles/bump_version.sh
+++ b/.makefiles/bump_version.sh
@@ -29,8 +29,10 @@ if [ -f $VERSION ]; then
     V_MINOR=$((V_MINOR + 1))
     V_PATCH=0
     SUGGESTED_VERSION="$V_MAJOR.$V_MINOR.$V_PATCH"
-    echo -ne "${QUESTION_FLAG} ${CYAN}Enter a version number [${WHITE}$SUGGESTED_VERSION${CYAN}]: "
-    read INPUT_STRING
+    if [ "$SKIP_INPUT" = "" ]; then
+        echo -ne "${QUESTION_FLAG} ${CYAN}Enter a version number [${WHITE}$SUGGESTED_VERSION${CYAN}]: "
+        read INPUT_STRING
+    fi
     if [ "$INPUT_STRING" = "" ]; then
         INPUT_STRING=$SUGGESTED_VERSION
     fi
@@ -43,6 +45,8 @@ if [ -f $VERSION ]; then
     cat CHANGELOG.md >> tmpfile
     mv tmpfile CHANGELOG.md
     echo -e "$ADJUSTMENTS_MSG"
-    read
+    if [ "$SKIP_INPUT" = "" ]; then
+        read
+    fi
     git add CHANGELOG.md $VERSION package.json
 fi

--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -1,10 +1,38 @@
 set -e
 
 VERSION=$(cat version | awk '{$1=$1;print}')
-echo "publish version ${VERSION}"
-
 git config --local user.name "wangshijun"
 git config --local user.email "wangshijun2010@gmail.com"
+
+echo "check version ${VERSION}"
+NPM_VERSION=$(npm view @arcblock/blocklet-registry version)
+if [ "$VERSION" = "$NPM_VERSION" ]; then
+  echo "current version $VERSION is the latest published version, will bump to new version"
+  git remote remove origin
+  git remote add origin "https://$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG.git"
+  git remote -v
+  git pull origin master
+  git checkout master
+  git branch -a
+  echo 'bump version'
+  SKIP_INPUT=1 .makefiles/bump_version.sh
+  .makefiles/bump_node_version.sh
+  echo 'commit'
+  git status
+  git commit -m 'bump version'
+  echo 'push commit to master'
+  git status
+  cat package.json
+  cat version
+  cat CHANGELOG.md
+  git push origin master
+  VERSION=$(cat version)
+  echo "version $VERSION pushed, next travis build will be trigger"
+  echo "done"
+  exit
+fi
+
+echo "publish version ${VERSION}"
 
 make release
 npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"


### PR DESCRIPTION
ci: auto bump version if is same version in npm

支持通过 travis restart 触发重复执行 latest build

- 比较 local version 和 npm latest version
  - 如果相等，则自动bump version，commit，push，触发下一次 travis build，退出。
  - 如果不相等，同现有逻辑
- 通过环境变量 SKIP_INPUT 控制 bump_version.sh 跳过手动输入
- bump_version 中默认version由 x.{y+1}.0 改为 x.y.{z+1}